### PR TITLE
Support for allowedDates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Resy API uses `lowdb`, a small JSON db, to store its information. You can either
       "preferredTime": "19:30",
       "maxTime": "22:00",
       "shouldBook": true,
-      "partySize": 2
+      "partySize": 2,
+      "allowedDates": ["2022-06-07", "2022-06-08"]
     }
   ]
 }

--- a/src/controllers/VenuesService.ts
+++ b/src/controllers/VenuesService.ts
@@ -15,6 +15,7 @@ export interface VenueToWatch {
   maxTime: string;
   uuid: string;
   partySize?: number;
+  allowedDates: string[];
 }
 
 interface DbSchema {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -71,6 +71,17 @@ const refreshAvailabilityForVenue = async (venue: VenueToWatch) => {
       return;
     }
     for (const dateToCheck of availableDates) {
+
+      //if dateToCheck.date in list of dates
+      if(venue.allowedDates)
+      {        
+        if(venue.allowedDates.indexOf(dateToCheck.date) == -1)
+        {
+          log.info("skipping available date because of allowed dates flag");
+          continue;
+        }
+      }
+      
       const slots = (await service.getAvailableTimesForVenueAndDate(
         venue.id,
         dateToCheck.date,


### PR DESCRIPTION
I added an optional string array of allowed dates
```

{
  "venues": [
    {
      "name": "Cote",
      "id": 35676,
      "notified": false,
      "minTime": "17:00",
      "preferredTime": "19:30",
      "maxTime": "22:00",
      "shouldBook": true,
      "partySize": 2,
      "allowedDates": ["2022-06-07", "2022-06-08"]
    }
  ]
}
```

If allowed dates are set, the system will only attempt to book on those dates